### PR TITLE
Avoid O(n) complexity using Any() instead of Count()

### DIFF
--- a/src/Bower/Completion/BowerNameCompletionEntry.cs
+++ b/src/Bower/Completion/BowerNameCompletionEntry.cs
@@ -47,7 +47,7 @@ namespace JSON_Intellisense.Bower
                 string result = Helper.DownloadText(url);
                 var children = GetChildren(result);
 
-                if (children.Count() == 0)
+                if (!children.Any())
                 {
                     _dte.StatusBar.Text = "No packages found matching '" + searchTerm + "'";
                     base.Session.Dismiss();

--- a/src/NPM/Completion/NpmNameCompletionEntry.cs
+++ b/src/NPM/Completion/NpmNameCompletionEntry.cs
@@ -47,7 +47,7 @@ namespace JSON_Intellisense.NPM
                 string result = Helper.DownloadText(url);
                 var children = GetChildren(result);
 
-                if (children.Count() == 0)
+                if (!children.Any())
                 {
                     _dte.StatusBar.Text = "No packages found matching '" + searchTerm + "'";
                     base.Session.Dismiss();


### PR DESCRIPTION
We only want to know if IEnumerable has at least one element that is an O(1) operation but you are using Count() that is an O(n) operation. Any() fetchs an iterator and checks if MoveNext() return true:

public static bool Any<TSource>(this IEnumerable<TSource> source)
{
    if (source == null)
    {
        throw Error.ArgumentNull("source");
    }
    using (IEnumerator<TSource> enumerator = source.GetEnumerator())
    {
        if (enumerator.MoveNext())
        {
            return true;
        }
    }
    return false;
}

Imagine that bower returns a huge numbers of packages :)

Regards!
